### PR TITLE
Change SDK version to one published on nuget

### DIFF
--- a/VersionOne.ServiceHost.Core/packages.config
+++ b/VersionOne.ServiceHost.Core/packages.config
@@ -7,5 +7,5 @@
   <package id="Ninject" version="3.2.2.0" targetFramework="net451" />
   <package id="OAuth2Client" version="1.6.1.2571" targetFramework="net45" allowedVersions="[1.6.0.2561,2)" />
   <package id="VersionOne.Parsers" version="1.1.0.0" targetFramework="net45" />
-  <package id="VersionOne.SDK.APIClient" version="14.1.1.292" targetFramework="net45" allowedVersions="[14.1.1.249,15)" />
+  <package id="VersionOne.SDK.APIClient" version="14.1.1.290" targetFramework="net45" allowedVersions="[14.1.1.249,15)" />
 </packages>


### PR DESCRIPTION
If you clone this straight up and attempt a build, it yells it can't find .292 -- a quick check of 

https://www.nuget.org/packages/VersionOne.SDK.APIClient/ 

show's 290 is something it can pull -- changing this allows for a successful build
